### PR TITLE
beforeContent.html: Link to StaticUIExtensions

### DIFF
--- a/server/templates/beforeContent.html
+++ b/server/templates/beforeContent.html
@@ -14,7 +14,8 @@
   ~ limitations under the License.
   -->
 <div style="background-color: #F9F9F9; margin-top: 1em; padding: 10px;  border: 1px solid #DDD; font-size: 14px;">
-  This is a <strong>beforeContent.html</strong> file content included by StaticUIExtensions plugin.
+  This is a <strong>beforeContent.html</strong> file content included by the
+  <a href="https://confluence.jetbrains.com/display/TW/StaticUIExtensions">StaticUIExtensions plugin</a>.
   This page will only be shown on overview pages.
   Refer to 
   <pre>[TeamCity Data Directory]/config/_static_ui_extensions/static-ui-extensions.xml</pre> 


### PR DESCRIPTION
So folks who see this message and are curious what it is can find out more, after the TeamCity administrator put it on their server.

<img width="939" alt="screen shot 2015-10-09 at 7 46 11 am" src="https://cloud.githubusercontent.com/assets/305268/10396920/dccf0748-6e59-11e5-8490-32912c56c5ef.png">

Note that in the above screenshot, "StaticUIExtensions plugin" is now a link.